### PR TITLE
[Feature] CoreDataManager 싱글톤 패턴 제거 및 의존성 주입

### DIFF
--- a/PickaView/Data/Persistence/CoreDataManager.swift
+++ b/PickaView/Data/Persistence/CoreDataManager.swift
@@ -9,13 +9,11 @@ import Foundation
 import CoreData
 
 final class CoreDataManager {
-    static let shared = CoreDataManager()
-
     let persistentContainer: NSPersistentContainer
     let mainContext: NSManagedObjectContext
     let fetchedResults: NSFetchedResultsController<Video>
 
-    private init() {
+    init() {
         // Core Data 스택 초기화
         let container = NSPersistentContainer(name: "Model")
         container.loadPersistentStores { storeDescription, error in
@@ -118,6 +116,6 @@ final class CoreDataManager {
             tag.lastUpdated = Date()
         }
 
-        CoreDataManager.shared.saveContext()
+        self.saveContext()
     }
 }

--- a/PickaView/MainViewController.swift
+++ b/PickaView/MainViewController.swift
@@ -8,11 +8,36 @@
 import UIKit
 
 class MainViewController: UITabBarController {
+    
+    let coreDataManager = CoreDataManager()
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         ThemeManager.shared.applyTheme()
         print("initial")
+        
+        if let viewControllers = viewControllers {
+            for vc in viewControllers {
+                if let nav = vc as? UINavigationController, let topVC = nav.topViewController {
+                    injectViewModel(to: topVC)
+                } else {
+                    injectViewModel(to: vc)
+                }
+            }
+        }
+    }
+    
+    private func injectViewModel(to viewController: UIViewController) {
+//        switch viewController {
+//        case let vc as HomeViewController:
+//            vc.viewModel = HomeViewModel(coreDataManager: coreDataManager)
+//        case let vc as LikeViewController:
+//            vc.viewModel = LikeViewModel(coreDataManager: coreDataManager)
+//        case let vc as MyPageViewController:
+//            vc.viewModel = MyPageViewController(coreDataManager: coreDataManager)
+//        case let vc as PlayerViewController:
+//            vc.viewModel = PlayerViewController(coreDataManager: coreDataManager)
+//        }
     }
 }


### PR DESCRIPTION
### 변경 내용

- CoreDataManager 싱글톤 패턴 제거
- MainViewController(UITabBarController)에서 의존성 주입

### 작업 목적
- 싱글톤 패턴의 단점
    - 객체 생명주기 제어 불가
        - 싱글톤 패턴은 앱 종료 전까지 메모리에서 해제되지 않음. 필요없는 시점에도 메모리를 사용하게 되어 메모리 누수로 이어질 수 있음.
    - 동시 접근 제어필요, Thread-safe 구현 복잡
- 의존성 주입
    - CoreDataManager 인스턴스를 공유
    - 더 이상 참조하지 않으면 ARC가 해제 (순환 참조 주의)