### PR TITLE
[Feature] CoreDataManager에 Video 기능 전반 구현 및 TimeStamp 리팩토링

### DIFF
--- a/PickaView/Data/Persistence/CoreDataManager.swift
+++ b/PickaView/Data/Persistence/CoreDataManager.swift
@@ -43,21 +43,41 @@ final class CoreDataManager {
 
     // MARK: - Fetch
 
-    func fetch() {
+    func fetch() -> [Video] {
         fetchedResults.fetchRequest.predicate = nil
         performFetch()
+        return fetchedResults.fetchedObjects ?? []
     }
 
-    func fetch(tag: String) {
+    func fetch(tag: String) -> [Video] {
         let predicate = NSPredicate(format: "SUBQUERY(tags, $tag, $tag.name CONTAINS[cd] %@).@count > 0", tag)
         fetchedResults.fetchRequest.predicate = predicate
         performFetch()
+        return fetchedResults.fetchedObjects ?? []
     }
 
     func fetchRecommended() -> [Video] {
+        fetchedResults.fetchRequest.predicate = nil
         performFetch()
         let videos = fetchedResults.fetchedObjects ?? []
         return VideoRecommender.sortVideosByRecommendationScore(from: videos)
+    }
+    
+    func fetchLiked() -> [Video] {
+        let predicate = NSPredicate(format: "isLiked == true")
+        fetchedResults.fetchRequest.predicate = predicate
+        performFetch()
+        return fetchedResults.fetchedObjects ?? []
+    }
+
+    // timeStamp.startDate가 존재하는 경우, 해당 필드로 내림차순 정렬하여 fetch
+    func fetchHistory() -> [Video] {
+        let predicate = NSPredicate(format: "timeStamp != nil")
+        let sortDescriptor = NSSortDescriptor(key: "timeStamp.startDate", ascending: false)
+        fetchedResults.fetchRequest.predicate = predicate
+        fetchedResults.fetchRequest.sortDescriptors = [sortDescriptor]
+        performFetch()
+        return fetchedResults.fetchedObjects ?? []
     }
 
     private func performFetch() {

--- a/PickaView/Model.xcdatamodeld/Model.xcdatamodel/contents
+++ b/PickaView/Model.xcdatamodeld/Model.xcdatamodel/contents
@@ -7,9 +7,9 @@
         <relationship name="videos" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Video" inverseName="tags" inverseEntity="Video"/>
     </entity>
     <entity name="TimeStamp" representedClassName="TimeStamp" syncable="YES" codeGenerationType="class">
-        <attribute name="endTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="startTime" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
-        <attribute name="whole" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
+        <attribute name="endDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="totalTime" attributeType="Double" defaultValueString="0.0" usesScalarValueType="YES"/>
         <relationship name="video" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Video" inverseName="timeStamp" inverseEntity="Video"/>
     </entity>
     <entity name="Video" representedClassName="Video" syncable="YES" codeGenerationType="class">


### PR DESCRIPTION
### 변경 내용

- TimeStamp Entity 속성명 변경 ('startTime', 'endTime', 'whole' → 'startDate', 'endDate', 'totalTime')
- CoreDataManager에 영상 데이터 관련 로직 전반 구현
  - fetch(tag:), fetchRecommended(), fetchLiked(), fetchWatched() 메서드 추가
  - saveVideos: 중복 검사 후 insert/update, 불필요한 항목 제거
  - insert: 신규 영상 저장 및 관련 태그(NSSet) 처리
  - update: apply 메서드로 필드 비교 후 수정
  - delete: ID 기준 영상 직접 삭제 기능 구현
- 시청 기록 업데이트 ('updateStartInfo', 'updateEndInfo') 및 종료 시점에서 tag score 반영
- 'updateTagScores'를 'updateEndTime' 내부에서 호출하도록 리팩토링
- 주요 메서드에 설명 주석 추가