### PR TITLE
[Fix] Pull-to-Refresh시 컬렉션 뷰 흰색 깜빡임 노출 버그 수정

### DIFF
--- a/PickaView/Common/Components/Extension.swift
+++ b/PickaView/Common/Components/Extension.swift
@@ -36,7 +36,6 @@ extension UIImageView {
     self.image = nil
     // 스켈레톤 뷰를 활성화하여 로딩 중임을 표시
     self.isSkeletonable = true
-    self.showAnimatedGradientSkeleton()
 
     guard let url = URL(string: urlString) else {
         print("Error: Invalid URL string.")

--- a/PickaView/Views/Home/HomeViewController.swift
+++ b/PickaView/Views/Home/HomeViewController.swift
@@ -8,21 +8,21 @@
 import UIKit
 
 class HomeViewController: UIViewController, ScrollToTopCapable {
-
+    
     var viewModel: HomeViewModel?
-
+    
     @IBOutlet weak var collectionView: UICollectionView!
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var tableViewHeightConstraint: NSLayoutConstraint!
-
+    
     // 탭 바에서 스크롤 최상단으로 이동하는 메서드 (ScrollToTopCapable 프로토콜 채택)
     func scrollToTop() {
         guard let collectionView = self.collectionView else { return }
         let topOffset = CGPoint(x: 0, y: -collectionView.adjustedContentInset.top)
         collectionView.setContentOffset(topOffset, animated: true)
     }
-
+    
     //가져온 비디오리스트를 저장하는 배열
     var videoList: [Video] = []
     //가져온 태그목록을 저장하는 배열
@@ -33,19 +33,19 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
     var isLoading: Bool = true
     //태그에 맞는 비디오 목록이 표시됐는지 bool 타입으로 확인
     var isTagSearchActive: Bool = false
-
+    
     //서치바에서 x	버튼 누르면 기존 비디오 배열을 보여준다
     var originalVideoList: [Video] = []
-
+    
     private var isLoadingNextPage = false
-
+    
     // 테이블뷰의 가시성 업데이트
     private func loadNextPageVideos() {
         guard !isLoadingNextPage else { return }  // 중복 호출 방지
         guard let viewModel = viewModel else { return }
-
+        
         isLoadingNextPage = true
-
+        
         Task {
             let nextPageVideos = viewModel.loadNextPage()
             if !nextPageVideos.isEmpty {
@@ -62,7 +62,7 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
             }
         }
     }
-
+    
     override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
         if let cell = sender as? VideoCollectionViewCell {
             if let indexPath = collectionView.indexPath(for: cell) {
@@ -75,7 +75,7 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
             }
         }
     }
-
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         collectionView.dataSource = self
@@ -88,18 +88,18 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
         searchBar.searchBarStyle = .minimal
         // 서치바에서 자동 대문자 입력 방지
         (searchBar.value(forKey: "searchField") as? UITextField)?.autocapitalizationType = .none
-
+        
         // 테이블뷰 초기 상태 숨기기
         updateTableViewVisibility(isVisible: false)
-
+        
         // 비동기로 view모델에서 모든 태그 가져옴
         Task {
             // 1. 비디오 + 태그 저장
             await viewModel?.fetchAndSaveVideos()
-
+            
             // 2. 저장된 태그 로드
             await viewModel?.loadAllTags()
-
+            
             // 3. UI에 반영
             await MainActor.run {
                 self.tags = viewModel?.allTags ?? []
@@ -108,22 +108,22 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
                 print("로드된 태그 개수: \(self.tags.count)")
             }
         }
-
+        
         Task {
             guard let viewModel = viewModel else {
                 print("viewModel이 아직 초기화되지 않았습니다.")
                 return
             }
-
+            
             // 1. 초기에 네트워크 호출 후 데이터를 가져와서 Core Data에 저장
             await viewModel.fetchAndSaveVideos(query: nil)
-
+            
             // 2. Core Data에서 정렬된 영상 불러와 내부 상태 갱신
             viewModel.refreshVideos()
-
+            
             // 3. 첫 페이지에 해당하는 추천된 영상들 받아오기
             let videosFromViewModel = viewModel.getCurrentPageVideos()
-
+            
             // 4. UI 업데이트는 메인 스레드에서
             await MainActor.run {
                 self.isLoading = false
@@ -132,8 +132,8 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
             }
         }
     }
-
-
+    
+    
     //화면 회전 시 레이아웃 업데이트
     override func viewWillTransition(to size: CGSize, with coordinator: UIViewControllerTransitionCoordinator) {
         super.viewWillTransition(to: size, with: coordinator)
@@ -142,41 +142,41 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
             self.collectionView.collectionViewLayout.invalidateLayout()//화면 회전시 셀 크기와 배치 다시 계산
         }, completion: nil)
     }
-
+    
     private func setupPullToRefresh() {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(refresh), for: .valueChanged)
         collectionView.refreshControl = refreshControl
     }
-
+    
     //화면 땡겼을 때 비디오 배열 추천 영상으로 새로고침
     @objc private func refresh() {
-
+        
         Task {
             guard let viewModel = viewModel else { return }
             // Core Data에서 새로 로딩
             viewModel.refreshVideos()
             // UI 업데이트
             await MainActor.run {
-                   let refreshedVideos = viewModel.getCurrentPageVideos()
-                   self.videoList = refreshedVideos
-                   self.originalVideoList = refreshedVideos  // 리프레시 시 기존 비디오 배열도 업데이트
-                   self.collectionView.reloadData()
-                   self.collectionView.refreshControl?.endRefreshing()
-
-                   // 햅틱
-                   let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
-                   feedbackGenerator.prepare()
-                   feedbackGenerator.impactOccurred()
-               }
-
+                let refreshedVideos = viewModel.getCurrentPageVideos()
+                self.videoList = refreshedVideos
+                self.originalVideoList = refreshedVideos  // 리프레시 시 기존 비디오 배열도 업데이트
+                self.collectionView.reloadData()
+                self.collectionView.refreshControl?.endRefreshing()
+                
+                // 햅틱
+                let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
+                feedbackGenerator.prepare()
+                feedbackGenerator.impactOccurred()
+            }
+            
         }
     }
 }
 
 //UICollectionView 설정
 extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelegateFlowLayout {
-
+    
     //셀은 비디오 개수 만큼 반환
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         return isLoading ? 10 : videoList.count
@@ -186,7 +186,7 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "Cell", for: indexPath) as? VideoCollectionViewCell else {
             fatalError("Failed to dequeue VideoCollectionViewCell")
         }
-
+        
         // 로딩 중일 때는 스켈레톤 뷰를 보여주고, 로딩이 끝나면 실제 데이터를 보여줌
         if isLoading {
             cell.configure(with: nil)
@@ -197,78 +197,78 @@ extension HomeViewController: UICollectionViewDataSource, UICollectionViewDelega
         }
         return cell
     }
-
+    
     // 셀 크기 설정
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
-
+        
         //현재 컬렉션 뷰 크기
         let width = collectionView.bounds.width
         let height = collectionView.bounds.height
-
+        
         var itemsPerRow: CGFloat = 1 //한 행에 표시 할 아이템 수
         var insets: CGFloat = 10
-
+        
         // 디바이스 및 방향에 따라 열 수 결정
         let isPad = traitCollection.userInterfaceIdiom == .pad //아이패드일 때
         let isLandscape = width > height // 가로일때
-
+        
         if isPad {
             itemsPerRow = isLandscape ? 3 : 2 // 가로이면 셀 3개 아니면 2개 반환
         } else {
             itemsPerRow = isLandscape ? 2 : 1
             insets = isLandscape ? 10 : 0  // 아이폰 세로는 화면 꽉차게 설정
         }
-
+        
         let spacingBetweenViews: CGFloat = 6.33
         let spacing: CGFloat = 10 // 셀 간 간격
         let totalSpacing = spacing * (itemsPerRow - 1) + insets * 2
         let itemWidth = (width - totalSpacing) / itemsPerRow //한 줄에 몇개의 셀을 배치할지에 따라 셀의 너비 계산
-
+        
         let thumbnailHeight = itemWidth * 9 / 16
         let userImageHeight = itemWidth / 5  // 유저 이미지높이는 전체 셀 너비의 20퍼센트로 설정
         let totalHeight = thumbnailHeight + userImageHeight + spacingBetweenViews
-
+        
         return CGSize(width: itemWidth, height: totalHeight)
     }
-
+    
     //줄 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumLineSpacingForSectionAt section: Int) -> CGFloat {
         return 30
     }
-
+    
     //셀 사이 간격
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
         return 10
     }
-
+    
     //섹션마다의 여백
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, insetForSectionAt section: Int) -> UIEdgeInsets {
         let width = collectionView.bounds.width
         let height = collectionView.bounds.height
         let isPhonePortrait = traitCollection.userInterfaceIdiom == .phone && width < height
-
+        
         return isPhonePortrait ? .zero : UIEdgeInsets(top: 10, left: 10, bottom: 10, right: 10)
     }
 }
 
 // 태그 목록을 표시하는 TableView 관련 설정
 extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
-
+    
     func numberOfSections(in tableView: UITableView) -> Int {
         return 1
     }
-
+    
     // filteredTags를 기준으로 row 개수 리턴
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return filteredTags.isEmpty ? 1 : filteredTags.count
     }
-
+    
     // 셀 구성 - 태그 목록 표시 또는 '검색 결과 없음' 플레이스홀더
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: "tableViewCell", for: indexPath) as? SearchTableViewCell else {
             return UITableViewCell()
         }
-
+        
         if filteredTags.isEmpty {
             // 태그가 하나도 없으면 '검색 결과가 없습니다' 메시지
             cell.tagLabel.text = "No results found."
@@ -282,42 +282,42 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
         }
         return cell
     }
-
+    
     // 태그 선택 시 해당 태그로 필터링된 비디오 목록을 컬렉션뷰에 표시
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard !filteredTags.isEmpty else { return }
         guard let selectedTag = filteredTags[indexPath.row].name else { return }
         applyTagFilter(tagName: selectedTag)
     }
-
+    
     // 특정 태그 이름으로 비디오 목록을 필터링하고 UI를 업데이트하는 함수
     func applyTagFilter(tagName: String) {
         //필터 적용 전에 원래 보이던 비디오 리스트 저장
         originalVideoList = videoList
-
+        
         // 1. ViewModel에서 해당 태그 이름으로 필터링된 비디오 리스트를 가져옴
         let filteredVideos = viewModel?.fetchVideosForTag(tagName) ?? []
-
+        
         // 2. 현재 비디오 리스트를 필터링된 비디오들로 교체
         videoList = filteredVideos
-
+        
         // 3. 비디오 리스트가 바뀌었으니 컬렉션뷰를 새로고침해서 화면에 반영
         collectionView.reloadData()
-
+        
         collectionView.setContentOffset(.zero, animated: false) //스크롤 최상단으로 이동
-
+        
         isTagSearchActive = true
         collectionView.bounces = false
-
+        
         // 4. 검색바에 #과 태그 이름을 붙여서 보여줌
         searchBar.text = "#\(tagName)"
-
+        
         // 5. 검색바에서 키보드 내리기 (포커스 해제)
         searchBar.resignFirstResponder()
-
+        
         // 6. 태그 검색 목록 테이블뷰 숨김 처리
         updateTableViewVisibility(isVisible: false)
-
+        
         // 7. 태그 검색이 활성화된 상태로 표시
         isTagSearchActive = true
     }
@@ -327,16 +327,16 @@ extension HomeViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         // 컬렉션뷰인 경우에만 처리
         guard scrollView == collectionView else { return }
-
+        
         //태그된 상태 감지 하면 페이징 금지
         if isTagSearchActive {
             return
         }
-
+        
         let offsetY = scrollView.contentOffset.y
         let contentHeight = scrollView.contentSize.height
         let height = scrollView.frame.size.height
-
+        
         // 사용자가 스크롤을 끝에서 100pt 이내로 내렸다면 다음 페이지 로드
         if offsetY > contentHeight - height - 100 {
             loadNextPageVideos()

--- a/PickaView/Views/Home/HomeViewController.swift
+++ b/PickaView/Views/Home/HomeViewController.swift
@@ -161,7 +161,7 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
                 let refreshedVideos = viewModel.getCurrentPageVideos()
                 self.videoList = refreshedVideos
                 self.originalVideoList = refreshedVideos
-
+                //  performWithoutAnimation 사용하여 애니메이션 없이 컬렉션 뷰 업데이트
                 UIView.performWithoutAnimation {
                     self.collectionView.reloadSections(IndexSet(integer: 0))
                 }

--- a/PickaView/Views/Home/HomeViewController.swift
+++ b/PickaView/Views/Home/HomeViewController.swift
@@ -158,24 +158,18 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
             viewModel.refreshVideos()
             // UI 업데이트
             await MainActor.run {
-                let refreshedVideos = viewModel.getCurrentPageVideos()
-                self.videoList = refreshedVideos
-                self.originalVideoList = refreshedVideos
-                //  performWithoutAnimation 사용하여 애니메이션 없이 컬렉션 뷰 업데이트
-                UIView.performWithoutAnimation {
-                    self.collectionView.reloadSections(IndexSet(integer: 0))
-                }
+                   let refreshedVideos = viewModel.getCurrentPageVideos()
+                   self.videoList = refreshedVideos
+                   self.originalVideoList = refreshedVideos  // 리프레시 시 기존 비디오 배열도 업데이트
+                   self.collectionView.reloadData()
+                   self.collectionView.refreshControl?.endRefreshing()
 
-                if self.collectionView.refreshControl?.isRefreshing == true {
-                    self.collectionView.hideSkeleton()
-                }
+                   // 햅틱
+                   let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
+                   feedbackGenerator.prepare()
+                   feedbackGenerator.impactOccurred()
+               }
 
-                self.collectionView.refreshControl?.endRefreshing()
-
-                let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
-                feedbackGenerator.prepare()
-                feedbackGenerator.impactOccurred()
-            }
         }
     }
 }

--- a/PickaView/Views/Home/HomeViewController.swift
+++ b/PickaView/Views/Home/HomeViewController.swift
@@ -15,7 +15,7 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
     @IBOutlet weak var tableView: UITableView!
     @IBOutlet weak var searchBar: UISearchBar!
     @IBOutlet weak var tableViewHeightConstraint: NSLayoutConstraint!
-    
+
     // 탭 바에서 스크롤 최상단으로 이동하는 메서드 (ScrollToTopCapable 프로토콜 채택)
     func scrollToTop() {
         guard let collectionView = self.collectionView else { return }
@@ -154,19 +154,24 @@ class HomeViewController: UIViewController, ScrollToTopCapable {
 
         Task {
             guard let viewModel = viewModel else { return }
-
             // Core Data에서 새로 로딩
             viewModel.refreshVideos()
-
             // UI 업데이트
             await MainActor.run {
                 let refreshedVideos = viewModel.getCurrentPageVideos()
                 self.videoList = refreshedVideos
-                self.originalVideoList = refreshedVideos  // 리프레시 시 기존 비디오 배열도 업데이트
-                self.collectionView.reloadData()
+                self.originalVideoList = refreshedVideos
+
+                UIView.performWithoutAnimation {
+                    self.collectionView.reloadSections(IndexSet(integer: 0))
+                }
+
+                if self.collectionView.refreshControl?.isRefreshing == true {
+                    self.collectionView.hideSkeleton()
+                }
+
                 self.collectionView.refreshControl?.endRefreshing()
 
-                // 햅틱
                 let feedbackGenerator = UIImpactFeedbackGenerator(style: .heavy)
                 feedbackGenerator.prepare()
                 feedbackGenerator.impactOccurred()

--- a/PickaView/Views/Home/VideoCollectionViewCell.swift
+++ b/PickaView/Views/Home/VideoCollectionViewCell.swift
@@ -90,7 +90,7 @@ class VideoCollectionViewCell: UICollectionViewCell {
 
     // Skeleton 뷰 숨기기
     private func hideSkeleton() {
-        contentView.hideSkeleton()
+        contentView.hideSkeleton(reloadDataAfter: false, transition: .none)
     }
 
     //  MARK: - Data Binding , 셀에 비디오 데이터를 바인딩


### PR DESCRIPTION
- [x] Pull-to-Refresh시 Skeleton UI가 보이지 않도록 Animation 제어 

<table>
  <tr>
    <th>AS-IS</th>
    <th>TO-BE</th>
  </tr>
  <tr>
<td>
      <video src="https://github.com/user-attachments/assets/06d575b4-68a6-4194-ba75-111547fdf8cb" width=300 />
</td>
<td>
      <video src="https://github.com/user-attachments/assets/23dddd1c-79d5-4570-8c46-a8c353a0c3a6" width=300 />
</td>
  </tr>
</table>


