### PR TITLE
[홈]x버튼 눌렀을 때 전체비디오 목록으로 안돌아가는 버그 해결

### DIFF
--- a/PickaView/Views/Home/HomeViewController.swift
+++ b/PickaView/Views/Home/HomeViewController.swift
@@ -290,8 +290,11 @@ extension HomeViewController: UITableViewDataSource, UITableViewDelegate {
 
     // 특정 태그 이름으로 비디오 목록을 필터링하고 UI를 업데이트하는 함수
     func applyTagFilter(tagName: String) {
-        //필터 적용 전에 원래 보이던 비디오 리스트 저장
-        originalVideoList = videoList
+
+        // 0. 태그 필터가 처음 적용될 때만 원본 리스트를 저장
+        if !isTagSearchActive {
+            originalVideoList = videoList
+        }
 
         // 1. ViewModel에서 해당 태그 이름으로 필터링된 비디오 리스트를 가져옴
         let filteredVideos = viewModel?.fetchVideosForTag(tagName) ?? []


### PR DESCRIPTION
### 홈에서 태그 검색을 중첩적으로 하고 x버튼 눌렀을 때, 검색 직전 태그목록으로 돌아가는 버그 수정했습니다.


**변경전**

https://github.com/user-attachments/assets/9c29c654-6afa-47fc-adb7-f70c3e772fda






------------------------------------------------------------------------------------------

**변경후**

https://github.com/user-attachments/assets/62c09384-2b9c-4b19-8cfb-f09316b889a7




